### PR TITLE
Added support for zero or multiple call parameters

### DIFF
--- a/examples/micropost.gql
+++ b/examples/micropost.gql
@@ -1,0 +1,5 @@
+micropost( 15, 19 ) {
+  content,
+  stars,
+  user { handle }
+}

--- a/graphql-parser.js
+++ b/graphql-parser.js
@@ -41,34 +41,35 @@ module.exports = (function() {
         peg$c6 = { type: "literal", value: ".", description: "\".\"" },
         peg$c7 = function(call) { return call },
         peg$c8 = function(calls) { return Array.isArray(calls) ? calls : [calls]; },
-        peg$c9 = function(name, parameter) { return { call: name, parameter: parameter }},
+        peg$c9 = function(name, parameters) { return { call: name, parameters: parameters }},
         peg$c10 = "(",
         peg$c11 = { type: "literal", value: "(", description: "\"(\"" },
         peg$c12 = ")",
         peg$c13 = { type: "literal", value: ")", description: "\")\"" },
-        peg$c14 = function(parameter) { return parameter; },
-        peg$c15 = /^[a-zA-Z0-9]/,
-        peg$c16 = { type: "class", value: "[a-zA-Z0-9]", description: "[a-zA-Z0-9]" },
-        peg$c17 = function(parameter) { return parameter.join('') },
-        peg$c18 = "{",
-        peg$c19 = { type: "literal", value: "{", description: "\"{\"" },
-        peg$c20 = "}",
-        peg$c21 = { type: "literal", value: "}", description: "\"}\"" },
-        peg$c22 = function(properties) { return { properties: properties } },
-        peg$c23 = function(p) { return p },
-        peg$c24 = function(first, rest) { return [first].concat(rest); },
-        peg$c25 = function(properties) { return properties; },
-        peg$c26 = function(name) { return { name: name }; },
-        peg$c27 = function(name, properties) { return { name: name, properties: properties } },
-        peg$c28 = function(name, calls, properties) { return { name: name, calls: calls, properties: properties }; },
-        peg$c29 = ",",
-        peg$c30 = { type: "literal", value: ",", description: "\",\"" },
-        peg$c31 = /^[a-z0-9A-Z$]/,
-        peg$c32 = { type: "class", value: "[a-z0-9A-Z$]", description: "[a-z0-9A-Z$]" },
-        peg$c33 = function(identifier) { return identifier.join(''); },
-        peg$c34 = { type: "other", description: "whitespace" },
-        peg$c35 = /^[ \t\n\r]/,
-        peg$c36 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+        peg$c14 = function(call_parameters) { return call_parameters; },
+        peg$c15 = function(p) { return p },
+        peg$c16 = function(first, rest) { return [first].concat(rest); },
+        peg$c17 = function(parameter_list) { return parameter_list; },
+        peg$c18 = /^[a-zA-Z0-9]/,
+        peg$c19 = { type: "class", value: "[a-zA-Z0-9]", description: "[a-zA-Z0-9]" },
+        peg$c20 = function(parameter) { return parameter.join('') },
+        peg$c21 = "{",
+        peg$c22 = { type: "literal", value: "{", description: "\"{\"" },
+        peg$c23 = "}",
+        peg$c24 = { type: "literal", value: "}", description: "\"}\"" },
+        peg$c25 = function(properties) { return { properties: properties } },
+        peg$c26 = function(properties) { return properties; },
+        peg$c27 = function(name) { return { name: name }; },
+        peg$c28 = function(name, properties) { return { name: name, properties: properties } },
+        peg$c29 = function(name, calls, properties) { return { name: name, calls: calls, properties: properties }; },
+        peg$c30 = ",",
+        peg$c31 = { type: "literal", value: ",", description: "\",\"" },
+        peg$c32 = /^[a-z0-9A-Z$]/,
+        peg$c33 = { type: "class", value: "[a-z0-9A-Z$]", description: "[a-z0-9A-Z$]" },
+        peg$c34 = function(identifier) { return identifier.join(''); },
+        peg$c35 = { type: "other", description: "whitespace" },
+        peg$c36 = /^[ \t\n\r]/,
+        peg$c37 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -374,7 +375,7 @@ module.exports = (function() {
     }
 
     function peg$parsecall_parameters() {
-      var s0, s1, s2, s3, s4, s5, s6;
+      var s0, s1, s2, s3, s4, s5;
 
       s0 = peg$currPos;
       s1 = peg$parsews();
@@ -395,31 +396,22 @@ module.exports = (function() {
             s3 = peg$c2;
           }
           if (s3 !== peg$FAILED) {
-            s4 = peg$parseparamater();
+            s4 = peg$parseparameter_list();
             if (s4 === peg$FAILED) {
               s4 = peg$c2;
             }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parsews();
-              if (s5 === peg$FAILED) {
-                s5 = peg$c2;
+              if (input.charCodeAt(peg$currPos) === 41) {
+                s5 = peg$c12;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c13); }
               }
               if (s5 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s6 = peg$c12;
-                  peg$currPos++;
-                } else {
-                  s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c13); }
-                }
-                if (s6 !== peg$FAILED) {
-                  peg$reportedPos = s0;
-                  s1 = peg$c14(s4);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$c0;
-                }
+                peg$reportedPos = s0;
+                s1 = peg$c14(s4);
+                s0 = s1;
               } else {
                 peg$currPos = s0;
                 s0 = peg$c0;
@@ -444,27 +436,136 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parseparamater() {
+    function peg$parseparameter_list() {
+      var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+      s0 = peg$currPos;
+      s1 = peg$currPos;
+      s2 = peg$parseparameter();
+      if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$currPos;
+        s5 = peg$parsews();
+        if (s5 === peg$FAILED) {
+          s5 = peg$c2;
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parseproperty_separator();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parsews();
+            if (s7 === peg$FAILED) {
+              s7 = peg$c2;
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parseparameter();
+              if (s8 !== peg$FAILED) {
+                peg$reportedPos = s4;
+                s5 = peg$c15(s8);
+                s4 = s5;
+              } else {
+                peg$currPos = s4;
+                s4 = peg$c0;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$c0;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$c0;
+          }
+        } else {
+          peg$currPos = s4;
+          s4 = peg$c0;
+        }
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$currPos;
+          s5 = peg$parsews();
+          if (s5 === peg$FAILED) {
+            s5 = peg$c2;
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parseproperty_separator();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parsews();
+              if (s7 === peg$FAILED) {
+                s7 = peg$c2;
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parseparameter();
+                if (s8 !== peg$FAILED) {
+                  peg$reportedPos = s4;
+                  s5 = peg$c15(s8);
+                  s4 = s5;
+                } else {
+                  peg$currPos = s4;
+                  s4 = peg$c0;
+                }
+              } else {
+                peg$currPos = s4;
+                s4 = peg$c0;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$c0;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$c0;
+          }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsews();
+          if (s4 === peg$FAILED) {
+            s4 = peg$c2;
+          }
+          if (s4 !== peg$FAILED) {
+            peg$reportedPos = s1;
+            s2 = peg$c16(s2, s3);
+            s1 = s2;
+          } else {
+            peg$currPos = s1;
+            s1 = peg$c0;
+          }
+        } else {
+          peg$currPos = s1;
+          s1 = peg$c0;
+        }
+      } else {
+        peg$currPos = s1;
+        s1 = peg$c0;
+      }
+      if (s1 !== peg$FAILED) {
+        peg$reportedPos = s0;
+        s1 = peg$c17(s1);
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parseparameter() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c15.test(input.charAt(peg$currPos))) {
+      if (peg$c18.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c16); }
+        if (peg$silentFails === 0) { peg$fail(peg$c19); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c15.test(input.charAt(peg$currPos))) {
+          if (peg$c18.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c16); }
+            if (peg$silentFails === 0) { peg$fail(peg$c19); }
           }
         }
       } else {
@@ -472,7 +573,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c17(s1);
+        s1 = peg$c20(s1);
       }
       s0 = s1;
 
@@ -489,11 +590,11 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c18;
+          s2 = peg$c21;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c19); }
+          if (peg$silentFails === 0) { peg$fail(peg$c22); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -509,11 +610,11 @@ module.exports = (function() {
               }
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 125) {
-                  s6 = peg$c20;
+                  s6 = peg$c23;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c21); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c24); }
                 }
                 if (s6 !== peg$FAILED) {
                   s7 = peg$parsews();
@@ -522,7 +623,7 @@ module.exports = (function() {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$reportedPos = s0;
-                    s1 = peg$c22(s4);
+                    s1 = peg$c25(s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -575,7 +676,7 @@ module.exports = (function() {
             s7 = peg$parseproperty();
             if (s7 !== peg$FAILED) {
               peg$reportedPos = s4;
-              s5 = peg$c23(s7);
+              s5 = peg$c15(s7);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -602,7 +703,7 @@ module.exports = (function() {
               s7 = peg$parseproperty();
               if (s7 !== peg$FAILED) {
                 peg$reportedPos = s4;
-                s5 = peg$c23(s7);
+                s5 = peg$c15(s7);
                 s4 = s5;
               } else {
                 peg$currPos = s4;
@@ -619,7 +720,7 @@ module.exports = (function() {
         }
         if (s3 !== peg$FAILED) {
           peg$reportedPos = s1;
-          s2 = peg$c24(s2, s3);
+          s2 = peg$c16(s2, s3);
           s1 = s2;
         } else {
           peg$currPos = s1;
@@ -631,7 +732,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c25(s1);
+        s1 = peg$c26(s1);
       }
       s0 = s1;
 
@@ -664,7 +765,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c26(s1);
+          s1 = peg$c27(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -687,7 +788,7 @@ module.exports = (function() {
         s2 = peg$parseblock();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c27(s1, s2);
+          s1 = peg$c28(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -712,7 +813,7 @@ module.exports = (function() {
           s3 = peg$parseblock();
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c28(s1, s2, s3);
+            s1 = peg$c29(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -734,11 +835,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 44) {
-        s0 = peg$c29;
+        s0 = peg$c30;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c30); }
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
       }
 
       return s0;
@@ -749,22 +850,22 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c31.test(input.charAt(peg$currPos))) {
+      if (peg$c32.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c32); }
+        if (peg$silentFails === 0) { peg$fail(peg$c33); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c31.test(input.charAt(peg$currPos))) {
+          if (peg$c32.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c32); }
+            if (peg$silentFails === 0) { peg$fail(peg$c33); }
           }
         }
       } else {
@@ -772,7 +873,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c33(s1);
+        s1 = peg$c34(s1);
       }
       s0 = s1;
 
@@ -784,27 +885,27 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c35.test(input.charAt(peg$currPos))) {
+      if (peg$c36.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c35.test(input.charAt(peg$currPos))) {
+        if (peg$c36.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c36); }
+          if (peg$silentFails === 0) { peg$fail(peg$c37); }
         }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c34); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
 
       return s0;

--- a/graphql.pegjs
+++ b/graphql.pegjs
@@ -11,17 +11,26 @@ calls
     { return Array.isArray(calls) ? calls : [calls]; }
 
 call
-  = name:call_name parameter:call_parameters
-    { return { call: name, parameter: parameter }}
+  = name:call_name parameters:call_parameters
+    { return { call: name, parameters: parameters }}
 
 call_name
   = identifier
 
 call_parameters
-  = ws? '(' ws? parameter:paramater? ws? ')'
-    { return parameter; }
+  = ws? '(' ws? call_parameters:parameter_list? ')'
+    { return call_parameters; }
 
-paramater
+parameter_list
+  = parameter_list:(
+      first:parameter
+      rest:(ws? property_separator ws? p:parameter { return p })*
+      ws?
+      { return [first].concat(rest); }
+    )
+    { return parameter_list; }
+
+parameter
   = parameter:[a-zA-Z0-9]+ { return parameter.join('') }
 
 block


### PR DESCRIPTION
This change to the grammar allows zero or multiple (comma-separated) parameters to be passed to a call. An example .gql file has been added to test the functionality.
